### PR TITLE
Add Add To PDF shape and table samples

### DIFF
--- a/DotNET/Endpoint Examples/JSON Payload/pdf-with-added-shapes.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-with-added-shapes.cs
@@ -1,0 +1,44 @@
+/*
+ * What this sample does:
+ * - Uploads a PDF, then adds a review-panel background and divider line by resource ID.
+ * - Routed from Program.cs as: `dotnet run -- pdf-with-added-shapes <inputFile>`.
+ *
+ * Setup (environment):
+ * - Copy .env.example to .env
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
+ *     PDFREST_URL=https://eu-api.pdfrest.com
+ *   For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+
+using Newtonsoft.Json.Linq;
+using Samples;
+
+namespace Samples.EndpointExamples.JsonPayload;
+
+public static class PdfWithAddedShapes
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = SampleInput.RequireFile(args, "pdf-with-added-shapes");
+        var apiKey = SampleInput.RequireApiKey();
+        using var client = SampleInput.CreateClient();
+        var inputId = await SampleInput.UploadPdf(client, inputPath, apiKey);
+        var shapes = JArray.Parse("""
+            [
+              {"type":"rectangle","page":1,"x":54,"y":540,"width":504,"height":108,"fill_color_rgb":"245,247,250","stroke_color_rgb":"26,72,112","stroke_width":1,"tag_is_artifact":true},
+              {"type":"line","page":1,"x1":72,"y1":576,"x2":540,"y2":576,"stroke_color_rgb":"26,72,112","stroke_width":1.5,"tag_actual_text":"Review section divider","tag_structure_type":"Figure"}
+            ]
+            """);
+        var payload = new JObject
+        {
+            ["id"] = inputId,
+            ["shape_objects"] = shapes,
+            ["tag_enabled"] = true,
+            ["output"] = "review-panel",
+        };
+
+        using var request = SampleInput.JsonRequest("pdf-with-added-shapes", payload, apiKey);
+        await SampleInput.PrintResponse(client, request);
+    }
+}

--- a/DotNET/Endpoint Examples/JSON Payload/pdf-with-added-tables.cs
+++ b/DotNET/Endpoint Examples/JSON Payload/pdf-with-added-tables.cs
@@ -1,0 +1,43 @@
+/*
+ * What this sample does:
+ * - Uploads a PDF, then adds a tagged project-status table by resource ID.
+ * - Routed from Program.cs as: `dotnet run -- pdf-with-added-tables <inputFile>`.
+ *
+ * Setup (environment):
+ * - Copy .env.example to .env
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
+ *     PDFREST_URL=https://eu-api.pdfrest.com
+ *   For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+
+using Newtonsoft.Json.Linq;
+using Samples;
+
+namespace Samples.EndpointExamples.JsonPayload;
+
+public static class PdfWithAddedTables
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = SampleInput.RequireFile(args, "pdf-with-added-tables");
+        var apiKey = SampleInput.RequireApiKey();
+        using var client = SampleInput.CreateClient();
+        var inputId = await SampleInput.UploadPdf(client, inputPath, apiKey);
+        var payload = new JObject
+        {
+            ["id"] = inputId,
+            ["table_objects"] = CreateTable(),
+            ["tag_enabled"] = true,
+            ["tag_language"] = "en-US",
+            ["output"] = "project-status",
+        };
+
+        using var request = SampleInput.JsonRequest("pdf-with-added-tables", payload, apiKey);
+        await SampleInput.PrintResponse(client, request);
+    }
+
+    private static JArray CreateTable() => JArray.Parse("""
+        [{"page":1,"x":54,"y":540,"width":504,"columns":[{"width":210},{"width":144},{"width":150}],"tag_structure_type":"Table","style":{"padding":{"top":6,"right":8,"bottom":6,"left":8},"text_size":10},"header_rows":[{"cells":[{"text":"Milestone","tag_structure_type":"TH","style":{"background_color_rgb":[26,72,112],"text_color_rgb":[255,255,255]}},{"text":"Owner","tag_structure_type":"TH","style":{"background_color_rgb":[26,72,112],"text_color_rgb":[255,255,255]}},{"text":"Status","tag_structure_type":"TH","style":{"background_color_rgb":[26,72,112],"text_color_rgb":[255,255,255]}}]}],"rows":[{"cells":[{"text":"Requirements review"},{"text":"Maya Chen"},{"text":"Complete","tag_structure_type":"TD","style":{"background_color_rgb":[220,252,231]}}]},{"cells":[{"text":"Prototype delivery"},{"text":"Jordan Lee"},{"text":"In progress","tag_structure_type":"TD","style":{"background_color_rgb":[254,249,195]}}]},{"cells":[{"text":"Stakeholder approval"},{"text":"Avery Patel"},{"text":"Planned","tag_structure_type":"TD","style":{"background_color_rgb":[239,246,255]}}]}],"footer_rows":[{"cells":[{"text":"Next review: Friday, 10:00 AM","col_span":3,"tag_structure_type":"TD","style":{"background_color_rgb":[245,247,250],"text_color_rgb":[55,65,81]}}]}]}]
+        """);
+}

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-with-added-shapes.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-with-added-shapes.cs
@@ -1,0 +1,46 @@
+/*
+ * What this sample does:
+ * - Adds a review-panel background and divider line to a PDF via multipart/form-data.
+ * - Routed from Program.cs as: `dotnet run -- pdf-with-added-shapes-multipart <inputFile>`.
+ *
+ * Setup (environment):
+ * - Copy .env.example to .env
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
+ *     PDFREST_URL=https://eu-api.pdfrest.com
+ *   For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+
+using Newtonsoft.Json.Linq;
+using System.Text;
+using Samples;
+
+namespace Samples.EndpointExamples.MultipartPayload;
+
+public static class PdfWithAddedShapes
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = SampleInput.RequireFile(args, "pdf-with-added-shapes-multipart");
+        var apiKey = SampleInput.RequireApiKey();
+        var shapes = JArray.Parse("""
+            [
+              {"type":"rectangle","page":1,"x":54,"y":540,"width":504,"height":108,"fill_color_rgb":"245,247,250","stroke_color_rgb":"26,72,112","stroke_width":1,"tag_is_artifact":true},
+              {"type":"line","page":1,"x1":72,"y1":576,"x2":540,"y2":576,"stroke_color_rgb":"26,72,112","stroke_width":1.5,"tag_actual_text":"Review section divider","tag_structure_type":"Figure"}
+            ]
+            """);
+
+        using var client = SampleInput.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, "pdf-with-added-shapes");
+        request.Headers.TryAddWithoutValidation("Api-Key", apiKey);
+        request.Headers.Accept.Add(new("application/json"));
+        using var content = new MultipartFormDataContent();
+        content.Add(new ByteArrayContent(await File.ReadAllBytesAsync(inputPath)), "file", Path.GetFileName(inputPath));
+        content.Add(new StringContent(shapes.ToString(), Encoding.UTF8), "shape_objects");
+        content.Add(new StringContent("true"), "tag_enabled");
+        content.Add(new StringContent("review-panel"), "output");
+        request.Content = content;
+
+        await SampleInput.PrintResponse(client, request);
+    }
+}

--- a/DotNET/Endpoint Examples/Multipart Payload/pdf-with-added-tables.cs
+++ b/DotNET/Endpoint Examples/Multipart Payload/pdf-with-added-tables.cs
@@ -1,0 +1,60 @@
+/*
+ * What this sample does:
+ * - Adds a tagged project-status table with styled headers, status cells, and a footer.
+ * - Routed from Program.cs as: `dotnet run -- pdf-with-added-tables-multipart <inputFile>`.
+ *
+ * Setup (environment):
+ * - Copy .env.example to .env
+ * - Set PDFREST_API_KEY=your_api_key_here
+ * - Optional: set PDFREST_URL to override the API region. For EU/GDPR compliance and proximity, use:
+ *     PDFREST_URL=https://eu-api.pdfrest.com
+ *   For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+
+using Newtonsoft.Json.Linq;
+using System.Text;
+using Samples;
+
+namespace Samples.EndpointExamples.MultipartPayload;
+
+public static class PdfWithAddedTables
+{
+    public static async Task Execute(string[] args)
+    {
+        var inputPath = SampleInput.RequireFile(args, "pdf-with-added-tables-multipart");
+        var apiKey = SampleInput.RequireApiKey();
+        using var client = SampleInput.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, "pdf-with-added-tables");
+        request.Headers.TryAddWithoutValidation("Api-Key", apiKey);
+        request.Headers.Accept.Add(new("application/json"));
+        using var content = new MultipartFormDataContent();
+        content.Add(new ByteArrayContent(await File.ReadAllBytesAsync(inputPath)), "file", Path.GetFileName(inputPath));
+        content.Add(new StringContent(CreateTable().ToString(), Encoding.UTF8), "table_objects");
+        content.Add(new StringContent("true"), "tag_enabled");
+        content.Add(new StringContent("en-US"), "tag_language");
+        content.Add(new StringContent("project-status"), "output");
+        request.Content = content;
+
+        await SampleInput.PrintResponse(client, request);
+    }
+
+    internal static JArray CreateTable() => JArray.Parse("""
+        [{
+          "page":1,"x":54,"y":540,"width":504,
+          "columns":[{"width":210},{"width":144},{"width":150}],
+          "tag_structure_type":"Table",
+          "style":{"padding":{"top":6,"right":8,"bottom":6,"left":8},"text_size":10},
+          "header_rows":[{"cells":[
+            {"text":"Milestone","tag_structure_type":"TH","style":{"background_color_rgb":[26,72,112],"text_color_rgb":[255,255,255]}},
+            {"text":"Owner","tag_structure_type":"TH","style":{"background_color_rgb":[26,72,112],"text_color_rgb":[255,255,255]}},
+            {"text":"Status","tag_structure_type":"TH","style":{"background_color_rgb":[26,72,112],"text_color_rgb":[255,255,255]}}
+          ]}],
+          "rows":[
+            {"cells":[{"text":"Requirements review"},{"text":"Maya Chen"},{"text":"Complete","tag_structure_type":"TD","style":{"background_color_rgb":[220,252,231]}}]},
+            {"cells":[{"text":"Prototype delivery"},{"text":"Jordan Lee"},{"text":"In progress","tag_structure_type":"TD","style":{"background_color_rgb":[254,249,195]}}]},
+            {"cells":[{"text":"Stakeholder approval"},{"text":"Avery Patel"},{"text":"Planned","tag_structure_type":"TD","style":{"background_color_rgb":[239,246,255]}}]}
+          ],
+          "footer_rows":[{"cells":[{"text":"Next review: Friday, 10:00 AM","col_span":3,"tag_structure_type":"TD","style":{"background_color_rgb":[245,247,250],"text_color_rgb":[55,65,81]}}]}]
+        }]
+        """);
+}

--- a/DotNET/Program.cs
+++ b/DotNET/Program.cs
@@ -41,6 +41,8 @@ static void PrintUsage()
     Console.Error.WriteLine("    pdf-with-added-attachment <pdf> <file>  Attach file");
     Console.Error.WriteLine("    pdf-with-converted-colors <pdf>    Convert colors to profile");
     Console.Error.WriteLine("    pdf-with-added-text <pdf>          Add text objects");
+    Console.Error.WriteLine("    pdf-with-added-shapes <pdf>        Add review-panel shapes");
+    Console.Error.WriteLine("    pdf-with-added-tables <pdf>        Add tagged project-status table");
     Console.Error.WriteLine("    pdf-with-acroforms <pdf>           Add acroforms");
     Console.Error.WriteLine("    pdf-with-page-boxes-set <pdf>      Set page boxes");
     Console.Error.WriteLine("  Redaction:");
@@ -92,6 +94,8 @@ static void PrintUsage()
     Console.Error.WriteLine("    pdf-with-added-attachment-multipart <pdf> <file>  Attach file");
     Console.Error.WriteLine("    pdf-with-converted-colors-multipart <pdf>  Convert colors to profile");
     Console.Error.WriteLine("    pdf-with-added-text-multipart <pdf>   Add text objects");
+    Console.Error.WriteLine("    pdf-with-added-shapes-multipart <pdf> Add review-panel shapes");
+    Console.Error.WriteLine("    pdf-with-added-tables-multipart <pdf> Add tagged project-status table");
     Console.Error.WriteLine("    pdf-with-acroforms-multipart <pdf>    Add acroforms");
     Console.Error.WriteLine("    pdf-with-page-boxes-set-multipart <pdf>  Set page boxes");
     Console.Error.WriteLine("  Redaction:");
@@ -417,6 +421,18 @@ switch (cmd)
         break;
     case "pdf-with-added-text-multipart":
         await Samples.EndpointExamples.MultipartPayload.PdfWithAddedText.Execute(rest);
+        break;
+    case "pdf-with-added-shapes":
+        await Samples.EndpointExamples.JsonPayload.PdfWithAddedShapes.Execute(rest);
+        break;
+    case "pdf-with-added-shapes-multipart":
+        await Samples.EndpointExamples.MultipartPayload.PdfWithAddedShapes.Execute(rest);
+        break;
+    case "pdf-with-added-tables":
+        await Samples.EndpointExamples.JsonPayload.PdfWithAddedTables.Execute(rest);
+        break;
+    case "pdf-with-added-tables-multipart":
+        await Samples.EndpointExamples.MultipartPayload.PdfWithAddedTables.Execute(rest);
         break;
     case "pdf-with-acroforms":
         await Samples.EndpointExamples.JsonPayload.PdfWithAcroforms.Execute(rest);

--- a/DotNET/SampleInput.cs
+++ b/DotNET/SampleInput.cs
@@ -1,0 +1,85 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Text;
+
+namespace Samples;
+
+internal static class SampleInput
+{
+    internal static string RequireFile(string[] args, string command)
+    {
+        if (args.Length > 0 && File.Exists(args[0]))
+        {
+            return args[0];
+        }
+
+        Console.Error.WriteLine($"{command} requires an existing <inputFile>");
+        Environment.Exit(1);
+        return string.Empty;
+    }
+
+    internal static string RequireApiKey()
+    {
+        var apiKey = Environment.GetEnvironmentVariable("PDFREST_API_KEY");
+        if (!string.IsNullOrWhiteSpace(apiKey))
+        {
+            return apiKey;
+        }
+
+        Console.Error.WriteLine("Missing required environment variable: PDFREST_API_KEY");
+        Environment.Exit(1);
+        return string.Empty;
+    }
+
+    internal static HttpClient CreateClient() => new()
+    {
+        BaseAddress = new Uri(Environment.GetEnvironmentVariable("PDFREST_URL") ?? "https://api.pdfrest.com"),
+    };
+
+    internal static HttpRequestMessage JsonRequest(string path, JObject payload, string apiKey)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, path);
+        request.Headers.TryAddWithoutValidation("Api-Key", apiKey);
+        request.Headers.Accept.Add(new("application/json"));
+        request.Content = new StringContent(payload.ToString(Formatting.None), Encoding.UTF8, "application/json");
+        return request;
+    }
+
+    internal static async Task<string> UploadPdf(HttpClient client, string inputPath, string apiKey)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "upload");
+        request.Headers.TryAddWithoutValidation("Api-Key", apiKey);
+        request.Headers.TryAddWithoutValidation("Content-Filename", Path.GetFileName(inputPath));
+        request.Content = new ByteArrayContent(await File.ReadAllBytesAsync(inputPath));
+        request.Content.Headers.ContentType = new("application/octet-stream");
+        using var response = await client.SendAsync(request);
+        var responseText = await response.Content.ReadAsStringAsync();
+        if (!response.IsSuccessStatusCode)
+        {
+            Console.Error.WriteLine(responseText);
+            Environment.Exit(1);
+        }
+
+        var inputId = JObject.Parse(responseText)["files"]?[0]?["id"]?.Value<string>();
+        if (!string.IsNullOrWhiteSpace(inputId))
+        {
+            return inputId;
+        }
+
+        Console.Error.WriteLine("The PDF upload did not return a resource ID.");
+        Environment.Exit(1);
+        return string.Empty;
+    }
+
+    internal static async Task PrintResponse(HttpClient client, HttpRequestMessage request)
+    {
+        using var response = await client.SendAsync(request);
+        var responseText = await response.Content.ReadAsStringAsync();
+        Console.WriteLine($"Response status code: {(int)response.StatusCode}");
+        Console.WriteLine(responseText);
+        if (!response.IsSuccessStatusCode)
+        {
+            Environment.Exit(1);
+        }
+    }
+}

--- a/Java/Endpoint Examples/JSON Payload/PDFWithAddedShapes.java
+++ b/Java/Endpoint Examples/JSON Payload/PDFWithAddedShapes.java
@@ -36,12 +36,30 @@ public class PDFWithAddedShapes {
 
     JSONArray shapes =
         new JSONArray()
-            .put(new JSONObject().put("type", "rectangle").put("page", 1).put("x", 54).put("y", 540)
-                .put("width", 504).put("height", 108).put("fill_color_rgb", "245,247,250")
-                .put("stroke_color_rgb", "26,72,112").put("stroke_width", 1).put("tag_is_artifact", true))
-            .put(new JSONObject().put("type", "line").put("page", 1).put("x1", 72).put("y1", 576)
-                .put("x2", 540).put("y2", 576).put("stroke_color_rgb", "26,72,112").put("stroke_width", 1.5)
-                .put("tag_actual_text", "Review section divider").put("tag_structure_type", "Figure"));
+            .put(
+                new JSONObject()
+                    .put("type", "rectangle")
+                    .put("page", 1)
+                    .put("x", 54)
+                    .put("y", 540)
+                    .put("width", 504)
+                    .put("height", 108)
+                    .put("fill_color_rgb", "245,247,250")
+                    .put("stroke_color_rgb", "26,72,112")
+                    .put("stroke_width", 1)
+                    .put("tag_is_artifact", true))
+            .put(
+                new JSONObject()
+                    .put("type", "line")
+                    .put("page", 1)
+                    .put("x1", 72)
+                    .put("y1", 576)
+                    .put("x2", 540)
+                    .put("y2", 576)
+                    .put("stroke_color_rgb", "26,72,112")
+                    .put("stroke_width", 1.5)
+                    .put("tag_actual_text", "Review section divider")
+                    .put("tag_structure_type", "Figure"));
     JSONObject payload =
         new JSONObject()
             .put("id", inputId)

--- a/Java/Endpoint Examples/JSON Payload/PDFWithAddedShapes.java
+++ b/Java/Endpoint Examples/JSON Payload/PDFWithAddedShapes.java
@@ -1,0 +1,91 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PDFWithAddedShapes {
+
+  // By default, we use the US-based API service. This is the primary endpoint for global use.
+  private static final String API_URL = "https://api.pdfrest.com";
+
+  // For GDPR compliance and enhanced performance for European users, you can switch to the EU-based
+  // service by commenting out the URL above and uncommenting the URL below.
+  // For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+  // private static final String API_URL = "https://eu-api.pdfrest.com";
+
+  private static final String DEFAULT_FILE_PATH = "/path/to/input.pdf";
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) {
+    File inputFile = new File(args.length > 0 ? args[0] : DEFAULT_FILE_PATH);
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+
+    String inputId = uploadFile(client, inputFile, apiKey);
+    if (inputId == null) {
+      return;
+    }
+
+    JSONArray shapes =
+        new JSONArray()
+            .put(new JSONObject().put("type", "rectangle").put("page", 1).put("x", 54).put("y", 540)
+                .put("width", 504).put("height", 108).put("fill_color_rgb", "245,247,250")
+                .put("stroke_color_rgb", "26,72,112").put("stroke_width", 1).put("tag_is_artifact", true))
+            .put(new JSONObject().put("type", "line").put("page", 1).put("x1", 72).put("y1", 576)
+                .put("x2", 540).put("y2", 576).put("stroke_color_rgb", "26,72,112").put("stroke_width", 1.5)
+                .put("tag_actual_text", "Review section divider").put("tag_structure_type", "Figure"));
+    JSONObject payload =
+        new JSONObject()
+            .put("id", inputId)
+            .put("shape_objects", shapes)
+            .put("tag_enabled", true)
+            .put("output", "review-panel");
+
+    Request request =
+        new Request.Builder()
+            .header("Accept", "application/json")
+            .header("Api-Key", apiKey)
+            .url(API_URL + "/pdf-with-added-shapes")
+            .post(RequestBody.create(payload.toString(), MediaType.parse("application/json")))
+            .build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Processing response status code: " + response.code());
+      if (response.body() != null) {
+        System.out.println(new JSONObject(response.body().string()).toString(2));
+      }
+    } catch (IOException error) {
+      throw new RuntimeException(error);
+    }
+  }
+
+  private static String uploadFile(OkHttpClient client, File inputFile, String apiKey) {
+    Request request =
+        new Request.Builder()
+            .header("Api-Key", apiKey)
+            .header("Content-Filename", inputFile.getName())
+            .url(API_URL + "/upload")
+            .post(RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+            .build();
+    try (Response response = client.newCall(request).execute()) {
+      if (response.body() == null) {
+        return null;
+      }
+      JSONObject result = new JSONObject(response.body().string());
+      if (!response.isSuccessful()) {
+        System.out.println(result.toString(2));
+        return null;
+      }
+      return result.getJSONArray("files").getJSONObject(0).getString("id");
+    } catch (IOException error) {
+      throw new RuntimeException(error);
+    }
+  }
+}

--- a/Java/Endpoint Examples/JSON Payload/PDFWithAddedTables.java
+++ b/Java/Endpoint Examples/JSON Payload/PDFWithAddedTables.java
@@ -1,0 +1,110 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PDFWithAddedTables {
+
+  // By default, we use the US-based API service. This is the primary endpoint for global use.
+  private static final String API_URL = "https://api.pdfrest.com";
+
+  // For GDPR compliance and enhanced performance for European users, you can switch to the EU-based
+  // service by commenting out the URL above and uncommenting the URL below.
+  // For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+  // private static final String API_URL = "https://eu-api.pdfrest.com";
+
+  private static final String DEFAULT_FILE_PATH = "/path/to/input.pdf";
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  private static final String TABLE_OBJECTS =
+      """
+      [{
+        "page": 1,
+        "x": 54,
+        "y": 540,
+        "width": 504,
+        "columns": [{"width": 210}, {"width": 144}, {"width": 150}],
+        "tag_structure_type": "Table",
+        "style": {"padding": {"top": 6, "right": 8, "bottom": 6, "left": 8}, "text_size": 10},
+        "header_rows": [{"cells": [
+          {"text": "Milestone", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}},
+          {"text": "Owner", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}},
+          {"text": "Status", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}}
+        ]}],
+        "rows": [
+          {"cells": [{"text": "Requirements review"}, {"text": "Maya Chen"}, {"text": "Complete", "tag_structure_type": "TD", "style": {"background_color_rgb": [220, 252, 231]}}]},
+          {"cells": [{"text": "Prototype delivery"}, {"text": "Jordan Lee"}, {"text": "In progress", "tag_structure_type": "TD", "style": {"background_color_rgb": [254, 249, 195]}}]},
+          {"cells": [{"text": "Stakeholder approval"}, {"text": "Avery Patel"}, {"text": "Planned", "tag_structure_type": "TD", "style": {"background_color_rgb": [239, 246, 255]}}]}
+        ],
+        "footer_rows": [{"cells": [
+          {"text": "Next review: Friday, 10:00 AM", "col_span": 3, "tag_structure_type": "TD", "style": {"background_color_rgb": [245, 247, 250], "text_color_rgb": [55, 65, 81]}}
+        ]}]
+      }]
+      """;
+
+  public static void main(String[] args) {
+    File inputFile = new File(args.length > 0 ? args[0] : DEFAULT_FILE_PATH);
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+    String apiKey = dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY);
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+
+    String inputId = uploadFile(client, inputFile, apiKey);
+    if (inputId == null) {
+      return;
+    }
+
+    JSONObject payload =
+        new JSONObject()
+            .put("id", inputId)
+            .put("table_objects", new JSONArray(TABLE_OBJECTS))
+            .put("tag_enabled", true)
+            .put("tag_language", "en-US")
+            .put("output", "project-status");
+    Request request =
+        new Request.Builder()
+            .header("Accept", "application/json")
+            .header("Api-Key", apiKey)
+            .url(API_URL + "/pdf-with-added-tables")
+            .post(RequestBody.create(payload.toString(), MediaType.parse("application/json")))
+            .build();
+
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Processing response status code: " + response.code());
+      if (response.body() != null) {
+        System.out.println(new JSONObject(response.body().string()).toString(2));
+      }
+    } catch (IOException error) {
+      throw new RuntimeException(error);
+    }
+  }
+
+  private static String uploadFile(OkHttpClient client, File inputFile, String apiKey) {
+    Request request =
+        new Request.Builder()
+            .header("Api-Key", apiKey)
+            .header("Content-Filename", inputFile.getName())
+            .url(API_URL + "/upload")
+            .post(RequestBody.create(inputFile, MediaType.parse("application/octet-stream")))
+            .build();
+    try (Response response = client.newCall(request).execute()) {
+      if (response.body() == null) {
+        return null;
+      }
+      JSONObject result = new JSONObject(response.body().string());
+      if (!response.isSuccessful()) {
+        System.out.println(result.toString(2));
+        return null;
+      }
+      return result.getJSONArray("files").getJSONObject(0).getString("id");
+    } catch (IOException error) {
+      throw new RuntimeException(error);
+    }
+  }
+}

--- a/Java/Endpoint Examples/Multipart Payload/PDFWithAddedShapes.java
+++ b/Java/Endpoint Examples/Multipart Payload/PDFWithAddedShapes.java
@@ -1,0 +1,87 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PDFWithAddedShapes {
+
+  // By default, we use the US-based API service. This is the primary endpoint for global use.
+  private static final String API_URL = "https://api.pdfrest.com";
+
+  // For GDPR compliance and enhanced performance for European users, you can switch to the EU-based
+  // service by commenting out the URL above and uncommenting the URL below.
+  // For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+  // private static final String API_URL = "https://eu-api.pdfrest.com";
+
+  private static final String DEFAULT_FILE_PATH = "/path/to/input.pdf";
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  public static void main(String[] args) {
+    File inputFile = new File(args.length > 0 ? args[0] : DEFAULT_FILE_PATH);
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+
+    // Add a lightly shaded review panel and a divider line to page one.
+    // Coordinates are measured from the lower-left corner in PDF units (72 units = 1 inch).
+    JSONArray shapes =
+        new JSONArray()
+            .put(
+                new JSONObject()
+                    .put("type", "rectangle")
+                    .put("page", 1)
+                    .put("x", 54)
+                    .put("y", 540)
+                    .put("width", 504)
+                    .put("height", 108)
+                    .put("fill_color_rgb", "245,247,250")
+                    .put("stroke_color_rgb", "26,72,112")
+                    .put("stroke_width", 1)
+                    .put("tag_is_artifact", true))
+            .put(
+                new JSONObject()
+                    .put("type", "line")
+                    .put("page", 1)
+                    .put("x1", 72)
+                    .put("y1", 576)
+                    .put("x2", 540)
+                    .put("y2", 576)
+                    .put("stroke_color_rgb", "26,72,112")
+                    .put("stroke_width", 1.5)
+                    .put("tag_actual_text", "Review section divider")
+                    .put("tag_structure_type", "Figure"));
+
+    RequestBody fileBody = RequestBody.create(inputFile, MediaType.parse("application/pdf"));
+    RequestBody requestBody =
+        new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("file", inputFile.getName(), fileBody)
+            .addFormDataPart("shape_objects", shapes.toString())
+            .addFormDataPart("tag_enabled", "true")
+            .addFormDataPart("output", "review-panel")
+            .build();
+    Request request =
+        new Request.Builder()
+            .header("Accept", "application/json")
+            .header("Api-Key", dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY))
+            .url(API_URL + "/pdf-with-added-shapes")
+            .post(requestBody)
+            .build();
+
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Response status code: " + response.code());
+      if (response.body() != null) {
+        System.out.println(new JSONObject(response.body().string()).toString(2));
+      }
+    } catch (IOException error) {
+      throw new RuntimeException(error);
+    }
+  }
+}

--- a/Java/Endpoint Examples/Multipart Payload/PDFWithAddedTables.java
+++ b/Java/Endpoint Examples/Multipart Payload/PDFWithAddedTables.java
@@ -1,0 +1,99 @@
+import io.github.cdimascio.dotenv.Dotenv;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class PDFWithAddedTables {
+
+  // By default, we use the US-based API service. This is the primary endpoint for global use.
+  private static final String API_URL = "https://api.pdfrest.com";
+
+  // For GDPR compliance and enhanced performance for European users, you can switch to the EU-based
+  // service by commenting out the URL above and uncommenting the URL below.
+  // For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+  // private static final String API_URL = "https://eu-api.pdfrest.com";
+
+  private static final String DEFAULT_FILE_PATH = "/path/to/input.pdf";
+  private static final String DEFAULT_API_KEY = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+  // This tagged table uses fixed widths that add up to the table width: 210 + 144 + 150 = 504.
+  private static final String TABLE_OBJECTS =
+      """
+      [
+        {
+          "page": 1,
+          "x": 54,
+          "y": 540,
+          "width": 504,
+          "columns": [{"width": 210}, {"width": 144}, {"width": 150}],
+          "tag_structure_type": "Table",
+          "style": {
+            "padding": {"top": 6, "right": 8, "bottom": 6, "left": 8},
+            "text_size": 10
+          },
+          "header_rows": [
+            {
+              "cells": [
+                {"text": "Milestone", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}},
+                {"text": "Owner", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}},
+                {"text": "Status", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}}
+              ]
+            }
+          ],
+          "rows": [
+            {"cells": [{"text": "Requirements review"}, {"text": "Maya Chen"}, {"text": "Complete", "tag_structure_type": "TD", "style": {"background_color_rgb": [220, 252, 231]}}]},
+            {"cells": [{"text": "Prototype delivery"}, {"text": "Jordan Lee"}, {"text": "In progress", "tag_structure_type": "TD", "style": {"background_color_rgb": [254, 249, 195]}}]},
+            {"cells": [{"text": "Stakeholder approval"}, {"text": "Avery Patel"}, {"text": "Planned", "tag_structure_type": "TD", "style": {"background_color_rgb": [239, 246, 255]}}]}
+          ],
+          "footer_rows": [
+            {
+              "cells": [
+                {"text": "Next review: Friday, 10:00 AM", "col_span": 3, "tag_structure_type": "TD", "style": {"background_color_rgb": [245, 247, 250], "text_color_rgb": [55, 65, 81]}}
+              ]
+            }
+          ]
+        }
+      ]
+      """;
+
+  public static void main(String[] args) {
+    File inputFile = new File(args.length > 0 ? args[0] : DEFAULT_FILE_PATH);
+    Dotenv dotenv = Dotenv.configure().ignoreIfMalformed().ignoreIfMissing().load();
+
+    RequestBody fileBody = RequestBody.create(inputFile, MediaType.parse("application/pdf"));
+    RequestBody requestBody =
+        new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("file", inputFile.getName(), fileBody)
+            .addFormDataPart("table_objects", new JSONArray(TABLE_OBJECTS).toString())
+            .addFormDataPart("tag_enabled", "true")
+            .addFormDataPart("tag_language", "en-US")
+            .addFormDataPart("output", "project-status")
+            .build();
+    Request request =
+        new Request.Builder()
+            .header("Accept", "application/json")
+            .header("Api-Key", dotenv.get("PDFREST_API_KEY", DEFAULT_API_KEY))
+            .url(API_URL + "/pdf-with-added-tables")
+            .post(requestBody)
+            .build();
+
+    OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    try (Response response = client.newCall(request).execute()) {
+      System.out.println("Response status code: " + response.code());
+      if (response.body() != null) {
+        System.out.println(new JSONObject(response.body().string()).toString(2));
+      }
+    } catch (IOException error) {
+      throw new RuntimeException(error);
+    }
+  }
+}

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-with-added-shapes.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-with-added-shapes.js
@@ -1,0 +1,70 @@
+/**
+ * Upload a PDF, then add a review-panel background and divider line by resource ID.
+ * PDF coordinates begin at the lower-left corner; 72 PDF units equal one inch.
+ */
+const axios = require("axios");
+const fs = require("fs");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+// const apiUrl = "https://eu-api.pdfrest.com";
+
+const apiKey = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"; // Replace with your API key.
+const shapes = [
+  {
+    type: "rectangle",
+    page: 1,
+    x: 54,
+    y: 540,
+    width: 504,
+    height: 108,
+    fill_color_rgb: "245,247,250",
+    stroke_color_rgb: "26,72,112",
+    stroke_width: 1,
+    tag_is_artifact: true,
+  },
+  {
+    type: "line",
+    page: 1,
+    x1: 72,
+    y1: 576,
+    x2: 540,
+    y2: 576,
+    stroke_color_rgb: "26,72,112",
+    stroke_width: 1.5,
+    tag_actual_text: "Review section divider",
+    tag_structure_type: "Figure",
+  },
+];
+
+async function addShapes() {
+  try {
+    const uploadResponse = await axios({
+      method: "post",
+      maxBodyLength: Infinity,
+      url: `${apiUrl}/upload`,
+      headers: {
+        "Api-Key": apiKey,
+        "Content-Filename": "input.pdf",
+        "Content-Type": "application/octet-stream",
+      },
+      data: fs.createReadStream("/path/to/input.pdf"),
+    });
+
+    const inputId = uploadResponse.data.files[0].id;
+    const response = await axios.post(
+      `${apiUrl}/pdf-with-added-shapes`,
+      { id: inputId, shape_objects: shapes, tag_enabled: true, output: "review-panel" },
+      { headers: { "Api-Key": apiKey } },
+    );
+    console.log(JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    console.log(error.response?.data || error.message);
+  }
+}
+
+addShapes();

--- a/JavaScript/Endpoint Examples/JSON Payload/pdf-with-added-tables.js
+++ b/JavaScript/Endpoint Examples/JSON Payload/pdf-with-added-tables.js
@@ -1,0 +1,63 @@
+/**
+ * Upload a PDF, then add an accessible project-status table by resource ID.
+ * The table includes header cells, colored status cells, and a footer row.
+ */
+const axios = require("axios");
+const fs = require("fs");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+// const apiUrl = "https://eu-api.pdfrest.com";
+
+const apiKey = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"; // Replace with your API key.
+const tables = [
+  {
+    page: 1,
+    x: 54,
+    y: 540,
+    width: 504,
+    columns: [{ width: 210 }, { width: 144 }, { width: 150 }],
+    tag_structure_type: "Table",
+    style: { padding: { top: 6, right: 8, bottom: 6, left: 8 }, text_size: 10 },
+    header_rows: [{ cells: [
+      { text: "Milestone", tag_structure_type: "TH", style: { background_color_rgb: [26, 72, 112], text_color_rgb: [255, 255, 255] } },
+      { text: "Owner", tag_structure_type: "TH", style: { background_color_rgb: [26, 72, 112], text_color_rgb: [255, 255, 255] } },
+      { text: "Status", tag_structure_type: "TH", style: { background_color_rgb: [26, 72, 112], text_color_rgb: [255, 255, 255] } },
+    ] }],
+    rows: [
+      { cells: [{ text: "Requirements review" }, { text: "Maya Chen" }, { text: "Complete", tag_structure_type: "TD", style: { background_color_rgb: [220, 252, 231] } }] },
+      { cells: [{ text: "Prototype delivery" }, { text: "Jordan Lee" }, { text: "In progress", tag_structure_type: "TD", style: { background_color_rgb: [254, 249, 195] } }] },
+      { cells: [{ text: "Stakeholder approval" }, { text: "Avery Patel" }, { text: "Planned", tag_structure_type: "TD", style: { background_color_rgb: [239, 246, 255] } }] },
+    ],
+    footer_rows: [{ cells: [
+      { text: "Next review: Friday, 10:00 AM", col_span: 3, tag_structure_type: "TD", style: { background_color_rgb: [245, 247, 250], text_color_rgb: [55, 65, 81] } },
+    ] }],
+  },
+];
+
+async function addTable() {
+  try {
+    const uploadResponse = await axios({
+      method: "post",
+      maxBodyLength: Infinity,
+      url: `${apiUrl}/upload`,
+      headers: { "Api-Key": apiKey, "Content-Filename": "input.pdf", "Content-Type": "application/octet-stream" },
+      data: fs.createReadStream("/path/to/input.pdf"),
+    });
+
+    const response = await axios.post(
+      `${apiUrl}/pdf-with-added-tables`,
+      { id: uploadResponse.data.files[0].id, table_objects: tables, tag_enabled: true, tag_language: "en-US", output: "project-status" },
+      { headers: { "Api-Key": apiKey } },
+    );
+    console.log(JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    console.log(error.response?.data || error.message);
+  }
+}
+
+addTable();

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-with-added-shapes.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-with-added-shapes.js
@@ -1,0 +1,63 @@
+/**
+ * Add a review-panel background and divider line to a PDF.
+ * PDF coordinates begin at the lower-left corner; 72 PDF units equal one inch.
+ */
+const axios = require("axios");
+const FormData = require("form-data");
+const fs = require("fs");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+// const apiUrl = "https://eu-api.pdfrest.com";
+
+const shapes = [
+  {
+    type: "rectangle",
+    page: 1,
+    x: 54,
+    y: 540,
+    width: 504,
+    height: 108,
+    fill_color_rgb: "245,247,250",
+    stroke_color_rgb: "26,72,112",
+    stroke_width: 1,
+    tag_is_artifact: true,
+  },
+  {
+    type: "line",
+    page: 1,
+    x1: 72,
+    y1: 576,
+    x2: 540,
+    y2: 576,
+    stroke_color_rgb: "26,72,112",
+    stroke_width: 1.5,
+    tag_actual_text: "Review section divider",
+    tag_structure_type: "Figure",
+  },
+];
+
+const form = new FormData();
+form.append("file", fs.createReadStream("/path/to/input.pdf"));
+form.append("shape_objects", JSON.stringify(shapes));
+form.append("tag_enabled", "true");
+form.append("output", "review-panel");
+
+axios({
+  method: "post",
+  maxBodyLength: Infinity,
+  url: `${apiUrl}/pdf-with-added-shapes`,
+  headers: {
+    "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // Replace with your API key.
+    ...form.getHeaders(),
+  },
+  data: form,
+})
+  .then((response) => console.log(JSON.stringify(response.data, null, 2)))
+  .catch((error) => console.log(error.response?.data || error.message));
+
+// To download the returned file, use the outputId with the get-resource-id endpoint sample.

--- a/JavaScript/Endpoint Examples/Multipart Payload/pdf-with-added-tables.js
+++ b/JavaScript/Endpoint Examples/Multipart Payload/pdf-with-added-tables.js
@@ -1,0 +1,69 @@
+/**
+ * Add an accessible, styled project-status table to a PDF.
+ * The table includes header cells, colored status cells, and a footer row.
+ */
+const axios = require("axios");
+const FormData = require("form-data");
+const fs = require("fs");
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+const apiUrl = "https://api.pdfrest.com";
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+// const apiUrl = "https://eu-api.pdfrest.com";
+
+const tables = [
+  {
+    page: 1,
+    x: 54,
+    y: 540,
+    width: 504,
+    columns: [{ width: 210 }, { width: 144 }, { width: 150 }],
+    tag_structure_type: "Table",
+    style: {
+      padding: { top: 6, right: 8, bottom: 6, left: 8 },
+      text_size: 10,
+    },
+    header_rows: [
+      {
+        cells: [
+          { text: "Milestone", tag_structure_type: "TH", style: { background_color_rgb: [26, 72, 112], text_color_rgb: [255, 255, 255] } },
+          { text: "Owner", tag_structure_type: "TH", style: { background_color_rgb: [26, 72, 112], text_color_rgb: [255, 255, 255] } },
+          { text: "Status", tag_structure_type: "TH", style: { background_color_rgb: [26, 72, 112], text_color_rgb: [255, 255, 255] } },
+        ],
+      },
+    ],
+    rows: [
+      { cells: [{ text: "Requirements review" }, { text: "Maya Chen" }, { text: "Complete", tag_structure_type: "TD", style: { background_color_rgb: [220, 252, 231] } }] },
+      { cells: [{ text: "Prototype delivery" }, { text: "Jordan Lee" }, { text: "In progress", tag_structure_type: "TD", style: { background_color_rgb: [254, 249, 195] } }] },
+      { cells: [{ text: "Stakeholder approval" }, { text: "Avery Patel" }, { text: "Planned", tag_structure_type: "TD", style: { background_color_rgb: [239, 246, 255] } }] },
+    ],
+    footer_rows: [
+      { cells: [{ text: "Next review: Friday, 10:00 AM", col_span: 3, tag_structure_type: "TD", style: { background_color_rgb: [245, 247, 250], text_color_rgb: [55, 65, 81] } }] },
+    ],
+  },
+];
+
+const form = new FormData();
+form.append("file", fs.createReadStream("/path/to/input.pdf"));
+form.append("table_objects", JSON.stringify(tables));
+form.append("tag_enabled", "true");
+form.append("tag_language", "en-US");
+form.append("output", "project-status");
+
+axios({
+  method: "post",
+  maxBodyLength: Infinity,
+  url: `${apiUrl}/pdf-with-added-tables`,
+  headers: {
+    "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", // Replace with your API key.
+    ...form.getHeaders(),
+  },
+  data: form,
+})
+  .then((response) => console.log(JSON.stringify(response.data, null, 2)))
+  .catch((error) => console.log(error.response?.data || error.message));
+
+// To download the returned file, use the outputId with the get-resource-id endpoint sample.

--- a/PHP/Endpoint Examples/JSON Payload/pdf-with-added-shapes.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-with-added-shapes.php
@@ -1,0 +1,51 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = 'https://api.pdfrest.com';
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+// $apiUrl = 'https://eu-api.pdfrest.com';
+
+$apiKey = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'; // Replace with your API key.
+$client = new Client(['http_errors' => false]);
+
+// Upload the input PDF first, then use its resource ID in a JSON endpoint call.
+$uploadResponse = $client->send(new Request('POST', $apiUrl . '/upload', [
+    'Api-Key' => $apiKey,
+    'Content-Filename' => 'input.pdf',
+    'Content-Type' => 'application/octet-stream',
+], file_get_contents('/path/to/input.pdf')));
+
+echo $uploadResponse->getBody() . PHP_EOL;
+$uploadResult = json_decode($uploadResponse->getBody(), true);
+if (!isset($uploadResult['files'][0]['id'])) {
+    exit("The PDF upload did not return a resource ID.\n");
+}
+
+$shapeObjects = [
+    ['type' => 'rectangle', 'page' => 1, 'x' => 54, 'y' => 540, 'width' => 504, 'height' => 108,
+        'fill_color_rgb' => '245,247,250', 'stroke_color_rgb' => '26,72,112', 'stroke_width' => 1, 'tag_is_artifact' => true],
+    ['type' => 'line', 'page' => 1, 'x1' => 72, 'y1' => 576, 'x2' => 540, 'y2' => 576,
+        'stroke_color_rgb' => '26,72,112', 'stroke_width' => 1.5,
+        'tag_actual_text' => 'Review section divider', 'tag_structure_type' => 'Figure'],
+];
+
+$requestBody = json_encode([
+    'id' => $uploadResult['files'][0]['id'],
+    'shape_objects' => $shapeObjects,
+    'tag_enabled' => true,
+    'output' => 'review-panel',
+]);
+$response = $client->send(new Request('POST', $apiUrl . '/pdf-with-added-shapes', [
+    'Accept' => 'application/json',
+    'Api-Key' => $apiKey,
+    'Content-Type' => 'application/json',
+], $requestBody));
+
+echo $response->getBody() . PHP_EOL;

--- a/PHP/Endpoint Examples/JSON Payload/pdf-with-added-tables.php
+++ b/PHP/Endpoint Examples/JSON Payload/pdf-with-added-tables.php
@@ -1,0 +1,68 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = 'https://api.pdfrest.com';
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+// $apiUrl = 'https://eu-api.pdfrest.com';
+
+function projectStatusTable(): array
+{
+    $headerStyle = ['background_color_rgb' => [26, 72, 112], 'text_color_rgb' => [255, 255, 255]];
+    return [[
+        'page' => 1, 'x' => 54, 'y' => 540, 'width' => 504,
+        'columns' => [['width' => 210], ['width' => 144], ['width' => 150]],
+        'tag_structure_type' => 'Table',
+        'style' => ['padding' => ['top' => 6, 'right' => 8, 'bottom' => 6, 'left' => 8], 'text_size' => 10],
+        'header_rows' => [['cells' => [
+            ['text' => 'Milestone', 'tag_structure_type' => 'TH', 'style' => $headerStyle],
+            ['text' => 'Owner', 'tag_structure_type' => 'TH', 'style' => $headerStyle],
+            ['text' => 'Status', 'tag_structure_type' => 'TH', 'style' => $headerStyle],
+        ]]],
+        'rows' => [
+            ['cells' => [['text' => 'Requirements review'], ['text' => 'Maya Chen'], ['text' => 'Complete', 'tag_structure_type' => 'TD', 'style' => ['background_color_rgb' => [220, 252, 231]]]]],
+            ['cells' => [['text' => 'Prototype delivery'], ['text' => 'Jordan Lee'], ['text' => 'In progress', 'tag_structure_type' => 'TD', 'style' => ['background_color_rgb' => [254, 249, 195]]]]],
+            ['cells' => [['text' => 'Stakeholder approval'], ['text' => 'Avery Patel'], ['text' => 'Planned', 'tag_structure_type' => 'TD', 'style' => ['background_color_rgb' => [239, 246, 255]]]]],
+        ],
+        'footer_rows' => [['cells' => [[
+            'text' => 'Next review: Friday, 10:00 AM', 'col_span' => 3, 'tag_structure_type' => 'TD',
+            'style' => ['background_color_rgb' => [245, 247, 250], 'text_color_rgb' => [55, 65, 81]],
+        ]]],
+    ]]];
+}
+
+$apiKey = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'; // Replace with your API key.
+$client = new Client(['http_errors' => false]);
+
+// Upload the input PDF first, then use its resource ID in a JSON endpoint call.
+$uploadResponse = $client->send(new Request('POST', $apiUrl . '/upload', [
+    'Api-Key' => $apiKey,
+    'Content-Filename' => 'input.pdf',
+    'Content-Type' => 'application/octet-stream',
+], file_get_contents('/path/to/input.pdf')));
+
+echo $uploadResponse->getBody() . PHP_EOL;
+$uploadResult = json_decode($uploadResponse->getBody(), true);
+if (!isset($uploadResult['files'][0]['id'])) {
+    exit("The PDF upload did not return a resource ID.\n");
+}
+
+$response = $client->send(new Request('POST', $apiUrl . '/pdf-with-added-tables', [
+    'Accept' => 'application/json',
+    'Api-Key' => $apiKey,
+    'Content-Type' => 'application/json',
+], json_encode([
+    'id' => $uploadResult['files'][0]['id'],
+    'table_objects' => projectStatusTable(),
+    'tag_enabled' => true,
+    'tag_language' => 'en-US',
+    'output' => 'project-status',
+])));
+
+echo $response->getBody() . PHP_EOL;

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-with-added-shapes.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-with-added-shapes.php
@@ -1,0 +1,45 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = 'https://api.pdfrest.com';
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+// $apiUrl = 'https://eu-api.pdfrest.com';
+
+// Add a lightly shaded review panel and a divider line to page one.
+// Coordinates are measured from the lower-left corner in PDF units (72 units = 1 inch).
+$shapeObjects = [
+    [
+        'type' => 'rectangle', 'page' => 1, 'x' => 54, 'y' => 540, 'width' => 504, 'height' => 108,
+        'fill_color_rgb' => '245,247,250', 'stroke_color_rgb' => '26,72,112', 'stroke_width' => 1,
+        'tag_is_artifact' => true,
+    ],
+    [
+        'type' => 'line', 'page' => 1, 'x1' => 72, 'y1' => 576, 'x2' => 540, 'y2' => 576,
+        'stroke_color_rgb' => '26,72,112', 'stroke_width' => 1.5,
+        'tag_actual_text' => 'Review section divider', 'tag_structure_type' => 'Figure',
+    ],
+];
+
+$request = new Request('POST', $apiUrl . '/pdf-with-added-shapes', [
+    'Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', // Replace with your API key.
+]);
+$response = (new Client(['http_errors' => false]))->send($request, [
+    'multipart' => [
+        ['name' => 'file', 'contents' => Utils::tryFopen('/path/to/input.pdf', 'r'), 'filename' => 'input.pdf'],
+        ['name' => 'shape_objects', 'contents' => json_encode($shapeObjects)],
+        ['name' => 'tag_enabled', 'contents' => 'true'],
+        ['name' => 'output', 'contents' => 'review-panel'],
+    ],
+]);
+
+echo $response->getBody() . PHP_EOL;
+
+// To download the returned file, use the outputId with the get-resource-id endpoint sample.

--- a/PHP/Endpoint Examples/Multipart Payload/pdf-with-added-tables.php
+++ b/PHP/Endpoint Examples/Multipart Payload/pdf-with-added-tables.php
@@ -1,0 +1,55 @@
+<?php
+require 'vendor/autoload.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+
+// By default, we use the US-based API service. This is the primary endpoint for global use.
+$apiUrl = 'https://api.pdfrest.com';
+
+/* For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+ * For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+ */
+// $apiUrl = 'https://eu-api.pdfrest.com';
+
+function projectStatusTable(): array
+{
+    $headerStyle = ['background_color_rgb' => [26, 72, 112], 'text_color_rgb' => [255, 255, 255]];
+    return [[
+        'page' => 1, 'x' => 54, 'y' => 540, 'width' => 504,
+        'columns' => [['width' => 210], ['width' => 144], ['width' => 150]],
+        'tag_structure_type' => 'Table',
+        'style' => ['padding' => ['top' => 6, 'right' => 8, 'bottom' => 6, 'left' => 8], 'text_size' => 10],
+        'header_rows' => [['cells' => [
+            ['text' => 'Milestone', 'tag_structure_type' => 'TH', 'style' => $headerStyle],
+            ['text' => 'Owner', 'tag_structure_type' => 'TH', 'style' => $headerStyle],
+            ['text' => 'Status', 'tag_structure_type' => 'TH', 'style' => $headerStyle],
+        ]]],
+        'rows' => [
+            ['cells' => [['text' => 'Requirements review'], ['text' => 'Maya Chen'], ['text' => 'Complete', 'tag_structure_type' => 'TD', 'style' => ['background_color_rgb' => [220, 252, 231]]]]],
+            ['cells' => [['text' => 'Prototype delivery'], ['text' => 'Jordan Lee'], ['text' => 'In progress', 'tag_structure_type' => 'TD', 'style' => ['background_color_rgb' => [254, 249, 195]]]]],
+            ['cells' => [['text' => 'Stakeholder approval'], ['text' => 'Avery Patel'], ['text' => 'Planned', 'tag_structure_type' => 'TD', 'style' => ['background_color_rgb' => [239, 246, 255]]]]],
+        ],
+        'footer_rows' => [['cells' => [[
+            'text' => 'Next review: Friday, 10:00 AM', 'col_span' => 3, 'tag_structure_type' => 'TD',
+            'style' => ['background_color_rgb' => [245, 247, 250], 'text_color_rgb' => [55, 65, 81]],
+        ]]],
+    ]]];
+}
+
+// Add an accessible project-status table with a header, colored status cells, and a footer.
+$request = new Request('POST', $apiUrl . '/pdf-with-added-tables', [
+    'Api-Key' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', // Replace with your API key.
+]);
+$response = (new Client(['http_errors' => false]))->send($request, [
+    'multipart' => [
+        ['name' => 'file', 'contents' => Utils::tryFopen('/path/to/input.pdf', 'r'), 'filename' => 'input.pdf'],
+        ['name' => 'table_objects', 'contents' => json_encode(projectStatusTable())],
+        ['name' => 'tag_enabled', 'contents' => 'true'],
+        ['name' => 'tag_language', 'contents' => 'en-US'],
+        ['name' => 'output', 'contents' => 'project-status'],
+    ],
+]);
+
+echo $response->getBody() . PHP_EOL;

--- a/Python/Endpoint Examples/JSON Payload/pdf-with-added-shapes.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-with-added-shapes.py
@@ -1,0 +1,68 @@
+import json
+
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# api_url = "https://eu-api.pdfrest.com"
+
+api_key = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  # Replace with your API key.
+shape_objects = [
+    {
+        "type": "rectangle",
+        "page": 1,
+        "x": 54,
+        "y": 540,
+        "width": 504,
+        "height": 108,
+        "fill_color_rgb": "245,247,250",
+        "stroke_color_rgb": "26,72,112",
+        "stroke_width": 1,
+        "tag_is_artifact": True,
+    },
+    {
+        "type": "line",
+        "page": 1,
+        "x1": 72,
+        "y1": 576,
+        "x2": 540,
+        "y2": 576,
+        "stroke_color_rgb": "26,72,112",
+        "stroke_width": 1.5,
+        "tag_actual_text": "Review section divider",
+        "tag_structure_type": "Figure",
+    },
+]
+
+# Upload the input PDF first, then use its resource ID in a JSON endpoint call.
+with open("/path/to/input.pdf", "rb") as input_file:
+    upload_response = requests.post(
+        f"{api_url}/upload",
+        data=input_file,
+        headers={
+            "Api-Key": api_key,
+            "Content-Filename": "input.pdf",
+            "Content-Type": "application/octet-stream",
+        },
+    )
+
+print(f"Upload response status code: {upload_response.status_code}")
+if not upload_response.ok:
+    print(upload_response.text)
+else:
+    input_id = upload_response.json()["files"][0]["id"]
+    response = requests.post(
+        f"{api_url}/pdf-with-added-shapes",
+        json={
+            "id": input_id,
+            "shape_objects": shape_objects,
+            "tag_enabled": True,
+            "output": "review-panel",
+        },
+        headers={"Accept": "application/json", "Api-Key": api_key},
+    )
+    print(f"Processing response status code: {response.status_code}")
+    print(json.dumps(response.json(), indent=2) if response.ok else response.text)

--- a/Python/Endpoint Examples/JSON Payload/pdf-with-added-tables.py
+++ b/Python/Endpoint Examples/JSON Payload/pdf-with-added-tables.py
@@ -1,0 +1,78 @@
+import json
+
+import requests
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# api_url = "https://eu-api.pdfrest.com"
+
+api_key = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  # Replace with your API key.
+
+
+def status_cell(text, color):
+    return {
+        "text": text,
+        "tag_structure_type": "TD",
+        "style": {"background_color_rgb": color},
+    }
+
+
+# Add an accessible project-status table with a header, colored status cells, and a footer.
+table_objects = [
+    {
+        "page": 1,
+        "x": 54,
+        "y": 540,
+        "width": 504,
+        "columns": [{"width": 210}, {"width": 144}, {"width": 150}],
+        "tag_structure_type": "Table",
+        "style": {"padding": {"top": 6, "right": 8, "bottom": 6, "left": 8}, "text_size": 10},
+        "header_rows": [{"cells": [
+            {"text": "Milestone", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}},
+            {"text": "Owner", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}},
+            {"text": "Status", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}},
+        ]}],
+        "rows": [
+            {"cells": [{"text": "Requirements review"}, {"text": "Maya Chen"}, status_cell("Complete", [220, 252, 231])]},
+            {"cells": [{"text": "Prototype delivery"}, {"text": "Jordan Lee"}, status_cell("In progress", [254, 249, 195])]},
+            {"cells": [{"text": "Stakeholder approval"}, {"text": "Avery Patel"}, status_cell("Planned", [239, 246, 255])]},
+        ],
+        "footer_rows": [{"cells": [
+            {"text": "Next review: Friday, 10:00 AM", "col_span": 3, "tag_structure_type": "TD", "style": {"background_color_rgb": [245, 247, 250], "text_color_rgb": [55, 65, 81]}}
+        ]}],
+    }
+]
+
+# Upload the input PDF first, then use its resource ID in a JSON endpoint call.
+with open("/path/to/input.pdf", "rb") as input_file:
+    upload_response = requests.post(
+        f"{api_url}/upload",
+        data=input_file,
+        headers={
+            "Api-Key": api_key,
+            "Content-Filename": "input.pdf",
+            "Content-Type": "application/octet-stream",
+        },
+    )
+
+print(f"Upload response status code: {upload_response.status_code}")
+if not upload_response.ok:
+    print(upload_response.text)
+else:
+    input_id = upload_response.json()["files"][0]["id"]
+    response = requests.post(
+        f"{api_url}/pdf-with-added-tables",
+        json={
+            "id": input_id,
+            "table_objects": table_objects,
+            "tag_enabled": True,
+            "tag_language": "en-US",
+            "output": "project-status",
+        },
+        headers={"Accept": "application/json", "Api-Key": api_key},
+    )
+    print(f"Processing response status code: {response.status_code}")
+    print(json.dumps(response.json(), indent=2) if response.ok else response.text)

--- a/Python/Endpoint Examples/Multipart Payload/pdf-with-added-shapes.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-with-added-shapes.py
@@ -1,0 +1,64 @@
+import json
+
+import requests
+from requests_toolbelt import MultipartEncoder
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# api_url = "https://eu-api.pdfrest.com"
+
+# Add a lightly shaded review panel and a divider line to page one.
+# Coordinates are measured from the lower-left corner in PDF units (72 units = 1 inch).
+shape_objects = [
+    {
+        "type": "rectangle",
+        "page": 1,
+        "x": 54,
+        "y": 540,
+        "width": 504,
+        "height": 108,
+        "fill_color_rgb": "245,247,250",
+        "stroke_color_rgb": "26,72,112",
+        "stroke_width": 1,
+        "tag_is_artifact": True,
+    },
+    {
+        "type": "line",
+        "page": 1,
+        "x1": 72,
+        "y1": 576,
+        "x2": 540,
+        "y2": 576,
+        "stroke_color_rgb": "26,72,112",
+        "stroke_width": 1.5,
+        "tag_actual_text": "Review section divider",
+        "tag_structure_type": "Figure",
+    },
+]
+
+with open("/path/to/input.pdf", "rb") as input_file:
+    multipart = MultipartEncoder(
+        fields={
+            "file": ("input.pdf", input_file, "application/pdf"),
+            "shape_objects": json.dumps(shape_objects),
+            "tag_enabled": "true",
+            "output": "review-panel",
+        }
+    )
+    response = requests.post(
+        f"{api_url}/pdf-with-added-shapes",
+        data=multipart,
+        headers={
+            "Accept": "application/json",
+            "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",  # Replace with your API key.
+            "Content-Type": multipart.content_type,
+        },
+    )
+
+print(f"Response status code: {response.status_code}")
+print(json.dumps(response.json(), indent=2) if response.ok else response.text)
+
+# To download the returned file, use the outputId with the get-resource-id endpoint sample.

--- a/Python/Endpoint Examples/Multipart Payload/pdf-with-added-tables.py
+++ b/Python/Endpoint Examples/Multipart Payload/pdf-with-added-tables.py
@@ -1,0 +1,67 @@
+import json
+
+import requests
+from requests_toolbelt import MultipartEncoder
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+api_url = "https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# api_url = "https://eu-api.pdfrest.com"
+
+# Add an accessible project-status table with a header, colored status cells, and a footer.
+table_objects = [
+    {
+        "page": 1,
+        "x": 54,
+        "y": 540,
+        "width": 504,
+        "columns": [{"width": 210}, {"width": 144}, {"width": 150}],
+        "tag_structure_type": "Table",
+        "style": {
+            "padding": {"top": 6, "right": 8, "bottom": 6, "left": 8},
+            "text_size": 10,
+        },
+        "header_rows": [
+            {
+                "cells": [
+                    {"text": "Milestone", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}},
+                    {"text": "Owner", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}},
+                    {"text": "Status", "tag_structure_type": "TH", "style": {"background_color_rgb": [26, 72, 112], "text_color_rgb": [255, 255, 255]}},
+                ]
+            }
+        ],
+        "rows": [
+            {"cells": [{"text": "Requirements review"}, {"text": "Maya Chen"}, {"text": "Complete", "tag_structure_type": "TD", "style": {"background_color_rgb": [220, 252, 231]}}]},
+            {"cells": [{"text": "Prototype delivery"}, {"text": "Jordan Lee"}, {"text": "In progress", "tag_structure_type": "TD", "style": {"background_color_rgb": [254, 249, 195]}}]},
+            {"cells": [{"text": "Stakeholder approval"}, {"text": "Avery Patel"}, {"text": "Planned", "tag_structure_type": "TD", "style": {"background_color_rgb": [239, 246, 255]}}]},
+        ],
+        "footer_rows": [
+            {"cells": [{"text": "Next review: Friday, 10:00 AM", "col_span": 3, "tag_structure_type": "TD", "style": {"background_color_rgb": [245, 247, 250], "text_color_rgb": [55, 65, 81]}}]}
+        ],
+    }
+]
+
+with open("/path/to/input.pdf", "rb") as input_file:
+    multipart = MultipartEncoder(
+        fields={
+            "file": ("input.pdf", input_file, "application/pdf"),
+            "table_objects": json.dumps(table_objects),
+            "tag_enabled": "true",
+            "tag_language": "en-US",
+            "output": "project-status",
+        }
+    )
+    response = requests.post(
+        f"{api_url}/pdf-with-added-tables",
+        data=multipart,
+        headers={
+            "Accept": "application/json",
+            "Api-Key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",  # Replace with your API key.
+            "Content-Type": multipart.content_type,
+        },
+    )
+
+print(f"Response status code: {response.status_code}")
+print(json.dumps(response.json(), indent=2) if response.ok else response.text)

--- a/cURL/Endpoint Examples/JSON Payload/pdf-with-added-shapes.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-with-added-shapes.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
+
+# Upload the input PDF first, then use its resource ID in a JSON endpoint call.
+UPLOAD_ID=$(curl --location "$API_URL/upload" \
+  --header 'Api-Key: xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' \
+  --header 'Content-Filename: input.pdf' \
+  --data-binary '@/path/to/input.pdf' | jq -r '.files[0].id')
+
+echo "File successfully uploaded with an ID of: $UPLOAD_ID"
+
+SHAPE_OBJECTS='[
+  {
+    "type": "rectangle",
+    "page": 1,
+    "x": 54,
+    "y": 540,
+    "width": 504,
+    "height": 108,
+    "fill_color_rgb": "245,247,250",
+    "stroke_color_rgb": "26,72,112",
+    "stroke_width": 1,
+    "tag_is_artifact": true
+  },
+  {
+    "type": "line",
+    "page": 1,
+    "x1": 72,
+    "y1": 576,
+    "x2": 540,
+    "y2": 576,
+    "stroke_color_rgb": "26,72,112",
+    "stroke_width": 1.5,
+    "tag_actual_text": "Review section divider",
+    "tag_structure_type": "Figure"
+  }
+]'
+
+jq -n --arg id "$UPLOAD_ID" --argjson shapes "$SHAPE_OBJECTS" '{id: $id, shape_objects: $shapes, tag_enabled: true, output: "review-panel"}' |
+  curl --location "$API_URL/pdf-with-added-shapes" \
+    --header 'Accept: application/json' \
+    --header 'Api-Key: xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' \
+    --header 'Content-Type: application/json' \
+    --data-binary @- | jq -r '.'

--- a/cURL/Endpoint Examples/JSON Payload/pdf-with-added-tables.sh
+++ b/cURL/Endpoint Examples/JSON Payload/pdf-with-added-tables.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
+
+# Upload the input PDF first, then use its resource ID in a JSON endpoint call.
+UPLOAD_ID=$(curl --location "$API_URL/upload" \
+  --header 'Api-Key: xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' \
+  --header 'Content-Filename: input.pdf' \
+  --data-binary '@/path/to/input.pdf' | jq -r '.files[0].id')
+
+echo "File successfully uploaded with an ID of: $UPLOAD_ID"
+
+TABLE_OBJECTS='[
+  {
+    "page": 1,
+    "x": 54,
+    "y": 540,
+    "width": 504,
+    "columns": [{"width": 210}, {"width": 144}, {"width": 150}],
+    "tag_structure_type": "Table",
+    "style": {"padding": {"top": 6, "right": 8, "bottom": 6, "left": 8}, "text_size": 10},
+    "header_rows": [{"cells": [
+      {"text": "Milestone", "tag_structure_type": "TH", "style": {"background_color_rgb": [26,72,112], "text_color_rgb": [255,255,255]}},
+      {"text": "Owner", "tag_structure_type": "TH", "style": {"background_color_rgb": [26,72,112], "text_color_rgb": [255,255,255]}},
+      {"text": "Status", "tag_structure_type": "TH", "style": {"background_color_rgb": [26,72,112], "text_color_rgb": [255,255,255]}}
+    ]}],
+    "rows": [
+      {"cells": [{"text": "Requirements review"}, {"text": "Maya Chen"}, {"text": "Complete", "tag_structure_type": "TD", "style": {"background_color_rgb": [220,252,231]}}]},
+      {"cells": [{"text": "Prototype delivery"}, {"text": "Jordan Lee"}, {"text": "In progress", "tag_structure_type": "TD", "style": {"background_color_rgb": [254,249,195]}}]},
+      {"cells": [{"text": "Stakeholder approval"}, {"text": "Avery Patel"}, {"text": "Planned", "tag_structure_type": "TD", "style": {"background_color_rgb": [239,246,255]}}]}
+    ],
+    "footer_rows": [{"cells": [
+      {"text": "Next review: Friday, 10:00 AM", "col_span": 3, "tag_structure_type": "TD", "style": {"background_color_rgb": [245,247,250], "text_color_rgb": [55,65,81]}}
+    ]}]
+  }
+]'
+
+jq -n --arg id "$UPLOAD_ID" --argjson tables "$TABLE_OBJECTS" '{id: $id, table_objects: $tables, tag_enabled: true, tag_language: "en-US", output: "project-status"}' |
+  curl --location "$API_URL/pdf-with-added-tables" \
+    --header 'Accept: application/json' \
+    --header 'Api-Key: xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' \
+    --header 'Content-Type: application/json' \
+    --data-binary @- | jq -r '.'

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-with-added-shapes.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-with-added-shapes.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
+
+# This example adds a lightly shaded review panel and a divider line to page one.
+# Coordinates are measured from the lower-left corner in PDF units (72 units = 1 inch).
+SHAPE_OBJECTS='[
+  {
+    "type": "rectangle",
+    "page": 1,
+    "x": 54,
+    "y": 540,
+    "width": 504,
+    "height": 108,
+    "fill_color_rgb": "245,247,250",
+    "stroke_color_rgb": "26,72,112",
+    "stroke_width": 1,
+    "tag_is_artifact": true
+  },
+  {
+    "type": "line",
+    "page": 1,
+    "x1": 72,
+    "y1": 576,
+    "x2": 540,
+    "y2": 576,
+    "stroke_color_rgb": "26,72,112",
+    "stroke_width": 1.5,
+    "tag_actual_text": "Review section divider",
+    "tag_structure_type": "Figure"
+  }
+]'
+
+curl -X POST "$API_URL/pdf-with-added-shapes" \
+  -H "Accept: application/json" \
+  -H "Content-Type: multipart/form-data" \
+  -H "Api-Key: xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -F "file=@/path/to/input.pdf" \
+  -F "shape_objects=$SHAPE_OBJECTS" \
+  -F "tag_enabled=true" \
+  -F "output=review-panel"

--- a/cURL/Endpoint Examples/Multipart Payload/pdf-with-added-tables.sh
+++ b/cURL/Endpoint Examples/Multipart Payload/pdf-with-added-tables.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# By default, we use the US-based API service. This is the primary endpoint for global use.
+API_URL="https://api.pdfrest.com"
+
+# For GDPR compliance and enhanced performance for European users, you can switch to the EU-based service by uncommenting the URL below.
+# For more information visit https://pdfrest.com/pricing#how-do-eu-gdpr-api-calls-work
+# API_URL="https://eu-api.pdfrest.com"
+
+# This example adds an accessible project-status table with a header, colored status cells, and a footer.
+TABLE_OBJECTS='[
+  {
+    "page": 1,
+    "x": 54,
+    "y": 540,
+    "width": 504,
+    "columns": [{"width": 210}, {"width": 144}, {"width": 150}],
+    "tag_structure_type": "Table",
+    "style": {"padding": {"top": 6, "right": 8, "bottom": 6, "left": 8}, "text_size": 10},
+    "header_rows": [{"cells": [
+      {"text": "Milestone", "tag_structure_type": "TH", "style": {"background_color_rgb": [26,72,112], "text_color_rgb": [255,255,255]}},
+      {"text": "Owner", "tag_structure_type": "TH", "style": {"background_color_rgb": [26,72,112], "text_color_rgb": [255,255,255]}},
+      {"text": "Status", "tag_structure_type": "TH", "style": {"background_color_rgb": [26,72,112], "text_color_rgb": [255,255,255]}}
+    ]}],
+    "rows": [
+      {"cells": [{"text": "Requirements review"}, {"text": "Maya Chen"}, {"text": "Complete", "tag_structure_type": "TD", "style": {"background_color_rgb": [220,252,231]}}]},
+      {"cells": [{"text": "Prototype delivery"}, {"text": "Jordan Lee"}, {"text": "In progress", "tag_structure_type": "TD", "style": {"background_color_rgb": [254,249,195]}}]},
+      {"cells": [{"text": "Stakeholder approval"}, {"text": "Avery Patel"}, {"text": "Planned", "tag_structure_type": "TD", "style": {"background_color_rgb": [239,246,255]}}]}
+    ],
+    "footer_rows": [{"cells": [
+      {"text": "Next review: Friday, 10:00 AM", "col_span": 3, "tag_structure_type": "TD", "style": {"background_color_rgb": [245,247,250], "text_color_rgb": [55,65,81]}}
+    ]}]
+  }
+]'
+
+curl -X POST "$API_URL/pdf-with-added-tables" \
+  -H "Accept: application/json" \
+  -H "Content-Type: multipart/form-data" \
+  -H "Api-Key: xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -F "file=@/path/to/input.pdf" \
+  -F "table_objects=$TABLE_OBJECTS" \
+  -F "tag_enabled=true" \
+  -F "tag_language=en-US" \
+  -F "output=project-status"


### PR DESCRIPTION
## Why this change

The Add To PDF service supports shapes and tables. These endpoint examples give developers a clear, runnable starting point for using those capabilities in each of the repository's primary languages.

## What changed

Adds JSON-payload and multipart-payload examples for `/pdf-with-added-shapes` and `/pdf-with-added-tables` in C#, Java, JavaScript, PHP, Python, and cURL. The shape example creates a tagged review panel with a divider line. The table example creates a tagged project-status table with styled headers, status cells, and a footer.

## Behavior changes

The repository now includes 24 new endpoint examples. JSON examples upload the source PDF first and pass its resource ID to the processing endpoint; multipart examples submit the source PDF and profile together. No existing samples or API behavior change.

## Validation

- .NET build passed with zero warnings and errors.
- Java 17 Maven verification passed for both payload styles, matching the CI workflow.
- PHP linting, JavaScript syntax checks, Python compilation, and shell syntax checks passed.

## Risks and follow-ups

These are endpoint examples only; complex-flow samples are intentionally out of scope for this change. They use placeholder API keys and input paths consistent with the rest of the repository.
